### PR TITLE
Feature/add get videos query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+__pycache__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ResearchTikPy"
-version = "0.1.10"
+version = "0.2.0"
 authors = [
   { name="Julian Hohner", email="daswaeldchen@gmail.com" },
 ]

--- a/src/researchtikpy/__init__.py
+++ b/src/researchtikpy/__init__.py
@@ -5,7 +5,7 @@ from .get_liked_videos import get_liked_videos
 from .get_pinned_videos import get_pinned_videos
 from .get_users_info import get_users_info
 from .get_video_comments import get_video_comments
-from .get_videos_hashtag import get_videos_hashtag
+from .get_videos_hashtag import get_videos_hashtag, get_videos_query
 from .get_videos_info import get_videos_info
 
 __all__ = [
@@ -17,5 +17,6 @@ __all__ = [
     'get_users_info',
     'get_video_comments',
     'get_videos_hashtag',
+    'get_videos_query',
     'get_videos_info',
 ]

--- a/src/researchtikpy/get_videos_hashtag.py
+++ b/src/researchtikpy/get_videos_hashtag.py
@@ -33,6 +33,7 @@ def get_videos_hashtag(hashtags, access_token, start_date, end_date, total_max_c
     endpoint = "https://open.tiktokapis.com/v2/research/video/query/"
     url_with_fields = f"{endpoint}?fields={fields}"
 
+    assert isinstance(access_token, str), "access_token must be a string!"
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {access_token}"

--- a/src/researchtikpy/get_videos_hashtag.py
+++ b/src/researchtikpy/get_videos_hashtag.py
@@ -9,6 +9,7 @@ import pandas as pd
 import time
 from datetime import datetime, timedelta
 
+
 def get_videos_hashtag(hashtags, access_token, start_date, end_date, total_max_count, region_code=None, music_id=None, effect_id=None, max_count=100, rate_limit_pause=60):
     """
     Searches for videos by hashtag with optional filters for region code, music ID, or effect ID, and includes rate limit handling. All available fields are retrieved by default, queries are segmented if the range between start_date and end_date exceeds 30 days.
@@ -28,6 +29,37 @@ def get_videos_hashtag(hashtags, access_token, start_date, end_date, total_max_c
     Returns:
     - A DataFrame containing the videos that match the given criteria.
     """
+    query: dict = _create_query(hashtags, region_code, music_id, effect_id)
+    return get_videos_query(
+        query=query,
+        access_token=access_token,
+        start_date=start_date,
+        end_date=end_date,
+        total_max_count=total_max_count,
+        max_count=max_count,
+        rate_limit_pause=rate_limit_pause
+    )
+
+
+def _create_query(hashtags: list[str], region_code: str, music_id: str, effect_id: str) -> dict:
+    and_conditions = [{"operation": "IN", "field_name": "hashtag_name", "field_values": hashtags}]
+    if region_code:
+        and_conditions.append({"operation": "EQ", "field_name": "region_code", "field_values": [region_code]})
+    if music_id:
+        and_conditions.append({"operation": "EQ", "field_name": "music_id", "field_values": [music_id]})
+    if effect_id:
+        and_conditions.append({"operation": "EQ", "field_name": "effect_id", "field_values": [effect_id]})
+    query = {"and": and_conditions}
+    return query
+
+
+def get_videos_query(query: dict, access_token: str, start_date: str, end_date: str, total_max_count: int, max_count=100, rate_limit_pause=60) -> pd.DataFrame:
+    """
+    Like get_videos_hashtag(), but you can pass a custom `query` object
+    For the `query` parameter, see the TikTok API documentation: https://developers.tiktok.com/doc/research-api-specs-query-videos/
+    For the rest of parameters, see get_videos_hashtag()
+    """
+
     fields = "id,video_description,create_time,region_code,share_count,view_count,like_count,comment_count,music_id,hashtag_names,username,effect_ids,playlist_id,voice_to_text"
 
     endpoint = "https://open.tiktokapis.com/v2/research/video/query/"
@@ -47,16 +79,9 @@ def get_videos_hashtag(hashtags, access_token, start_date, end_date, total_max_c
 
     while start_date_dt < end_date_dt:
         current_end_date = min(start_date_dt + delta, end_date_dt)
-        and_conditions = [{"operation": "IN", "field_name": "hashtag_name", "field_values": hashtags}]
-        if region_code:
-            and_conditions.append({"operation": "EQ", "field_name": "region_code", "field_values": [region_code]})
-        if music_id:
-            and_conditions.append({"operation": "EQ", "field_name": "music_id", "field_values": [music_id]})
-        if effect_id:
-            and_conditions.append({"operation": "EQ", "field_name": "effect_id", "field_values": [effect_id]})
 
         query_body = {
-            "query": {"and": and_conditions},
+            "query": query,
             "start_date": start_date_dt.strftime("%Y%m%d"),
             "end_date": current_end_date.strftime("%Y%m%d"),
             "max_count": max_count
@@ -79,4 +104,3 @@ def get_videos_hashtag(hashtags, access_token, start_date, end_date, total_max_c
         start_date_dt = current_end_date + timedelta(days=1)
 
     return pd.DataFrame(collected_videos[:total_max_count])
-

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,14 @@
+from functools import cache
+from researchtikpy import get_access_token
+
+
+import os
+
+
+@cache
+def access_token() -> str:
+    data: dict = get_access_token(
+        client_key=os.environ["TIKTOK_CLIENT_KEY"],
+        client_secret=os.environ["TIKTOK_CLIENT_SECRET"],
+    )
+    return data["access_token"]

--- a/tests/test_get_followers_notworkingyet (2).py
+++ b/tests/test_get_followers_notworkingyet (2).py
@@ -1,7 +1,7 @@
 # test_get_following.py
 import unittest
 from unittest.mock import patch, MagicMock
-from researchtikpy.src.get_following import get_following
+from researchtikpy import get_following
 import pandas as pd
 
 class TestGetFollowing(unittest.TestCase):

--- a/tests/test_get_followers_notworkingyet (3).py
+++ b/tests/test_get_followers_notworkingyet (3).py
@@ -2,7 +2,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import pandas as pd
-from researchtikpy.src.get_liked_videos import get_liked_videos
+from researchtikpy import get_liked_videos
 
 class TestGetLikedVideos(unittest.TestCase):
 

--- a/tests/test_get_videos_hashtags.py
+++ b/tests/test_get_videos_hashtags.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+import pandas as pd
+from researchtikpy import get_videos_hashtag, get_access_token
+
+class TestGetVideoHashtag(unittest.TestCase):
+    def test_get_videos_hashtag(self):
+        token: str = access_token()
+        df = get_videos_hashtag(
+            hashtags=["germany"],
+            access_token=token,
+            start_date="20240101",
+            end_date="20240102",
+            total_max_count=10
+        )
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) > 0
+
+
+def access_token() -> str:
+    data: dict = get_access_token(
+        client_key=os.environ["TIKTOK_CLIENT_KEY"],
+        client_secret=os.environ["TIKTOK_CLIENT_SECRET"],
+    )
+    return data["access_token"]

--- a/tests/test_get_videos_hashtags.py
+++ b/tests/test_get_videos_hashtags.py
@@ -1,8 +1,8 @@
-import os
 import unittest
-
 import pandas as pd
-from researchtikpy import get_videos_hashtag, get_access_token
+from researchtikpy import get_videos_hashtag
+from .helpers import access_token
+
 
 class TestGetVideoHashtag(unittest.TestCase):
     def test_get_videos_hashtag(self):
@@ -12,15 +12,8 @@ class TestGetVideoHashtag(unittest.TestCase):
             access_token=token,
             start_date="20240101",
             end_date="20240102",
-            total_max_count=10
+            total_max_count=10,
+            max_count=10
         )
         assert isinstance(df, pd.DataFrame)
         assert len(df) > 0
-
-
-def access_token() -> str:
-    data: dict = get_access_token(
-        client_key=os.environ["TIKTOK_CLIENT_KEY"],
-        client_secret=os.environ["TIKTOK_CLIENT_SECRET"],
-    )
-    return data["access_token"]

--- a/tests/test_get_videos_query.py
+++ b/tests/test_get_videos_query.py
@@ -1,0 +1,19 @@
+import unittest
+
+import pandas as pd
+from researchtikpy import get_videos_query
+from .helpers import access_token
+
+
+class TestGetVideosQuery(unittest.TestCase):
+    def test_get_videos_query(self):
+        df = get_videos_query(
+            query={"and": [{"operation": "IN", "field_name": "hashtag_name", "field_values": ["germany"]}]},
+            access_token=access_token(),
+            start_date="20240101",
+            end_date="20240102",
+            total_max_count=10,
+            max_count=10
+        )
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) > 0


### PR DESCRIPTION
* I added a new function `rtk.get_videos_query()`, with  the functionality of `rtk.get_videos_hashtag()`, but allowing to pass a `query: dict` object.
* I added a test file for each function: `rtk.get_videos_query()` and `rtk.get_videos_hashtag()`
* The tests need an access token, so they attempt to read the credentials from the environment variables: `TIKTOK_CLIENT_KEY`, and `TIKTOK_CLIENT_SECRET`
* Let me know if anything is unclear. We can have a chat about the changes, too 👍 