### PR TITLE
Bad request raises error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ResearchTikPy"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="Julian Hohner", email="daswaeldchen@gmail.com" },
 ]

--- a/src/researchtikpy/get_videos_hashtag.py
+++ b/src/researchtikpy/get_videos_hashtag.py
@@ -98,8 +98,7 @@ def get_videos_query(query: dict, access_token: str, start_date: str, end_date: 
             print("Rate limit exceeded. Pausing before retrying...")
             time.sleep(rate_limit_pause)
         else:
-            print(f"Error: {response.status_code}", response.json())
-            break
+            raise ValueError(f"status_code={response.status_code}. {response.json()}")
 
         start_date_dt = current_end_date + timedelta(days=1)
 

--- a/tests/test_get_videos_query.py
+++ b/tests/test_get_videos_query.py
@@ -17,3 +17,16 @@ class TestGetVideosQuery(unittest.TestCase):
         )
         assert isinstance(df, pd.DataFrame)
         assert len(df) > 0
+    
+    def test_invalid_query(self):
+        # 'operation' EQ must have one field value
+        invalid_query = {"and": [{"operation": "EQ", "field_name": "keyword", "field_values": ["one", "two"]}]}
+        with self.assertRaises(ValueError):
+            get_videos_query(
+                query=invalid_query,
+                access_token=access_token(),
+                start_date="20240101",
+                end_date="20240102",
+                total_max_count=10,
+                max_count=10
+            )


### PR DESCRIPTION
* A bad request should raise an exception
  * e.g. specifing a query as `keyword EQ ["germany", "usa"]`
  * this query is illegal because EQ only allows one value rather than two
  * The message returned by the API is: 

```
status_code=400. {'error': {'code': 'invalid_params', 'message': '`operation` EQ must have one field value', 'log_id': '20240617151959D361F770DE6E167E6900'}}
```

* Atm the function returns an empty `pd.DataFrame` in this case.
* Throwing an exception is better, because a UI could catch such exception using `try ... except` and display the message to the user, so that they can fix their query.
* Atm, the error is printed, but a user of a UI would not see those logs.
